### PR TITLE
Add rust-toolchain

### DIFF
--- a/fuzz/rust-toolchain
+++ b/fuzz/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
Fuzz can only be supported in nightly rust toolchain.